### PR TITLE
Downgrade android-pdf-viewer to stable version android-pdf-viewer:2.8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Library for displaying [PDF documents](https://acrobat.adobe.com/us/en/acrobat/about-adobe-pdf.html) in [react-native](http://facebook.github.io/react-native/)
 
-- android - uses [Android PdfViewer](https://github.com/barteksc/AndroidPdfViewer)
+- android - uses [Android PdfViewer](https://github.com/barteksc/AndroidPdfViewer). Stable version `com.github.barteksc:android-pdf-viewer:2.8.2` is used.
 
 - ios - uses [WKWebView](https://developer.apple.com/documentation/webkit/wkwebview).
 Targets iOS9.0 and above

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,5 +32,5 @@ repositories {
 
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    compile 'com.github.barteksc:android-pdf-viewer:3.0.0-beta.5'
+    compile 'com.github.barteksc:android-pdf-viewer:2.8.2'
 }

--- a/android/src/main/java/com/reactlibrary/PDFView.java
+++ b/android/src/main/java/com/reactlibrary/PDFView.java
@@ -14,7 +14,6 @@ import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.github.barteksc.pdfviewer.listener.OnErrorListener;
 import com.github.barteksc.pdfviewer.listener.OnLoadCompleteListener;
-import com.github.barteksc.pdfviewer.util.FitPolicy;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -72,7 +71,6 @@ public class PDFView extends com.github.barteksc.pdfviewer.PDFView implements
                 .onLoad(this)
                 .onError(this)
                 .spacing(10)
-                .pageFitPolicy(FitPolicy.WIDTH)
                 .load();
         sourceChanged = false;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-view-pdf",
-  "version": "0.1.24",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-view-pdf",
-  "version": "0.1.24",
+  "version": "0.2.0",
   "description": "React native Pdf viewer implementation",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
Downgrade android-pdf-viewer to stable version `com.github.barteksc:android-pdf-viewer:2.8.2`
Closes #29. 