### PR TITLE
Better error handling

### DIFF
--- a/ReactNativeViewPDF/PDFConstants.h
+++ b/ReactNativeViewPDF/PDFConstants.h
@@ -13,6 +13,10 @@ extern NSString * const URL_PROPS_METHOD_KEY;
 extern NSString * const URL_PROPS_HEADERS_KEY;
 extern NSString * const URL_PROPS_BODY_KEY;
 
+// Supported protocols
+extern NSString * const HTTP;
+extern NSString * const HTTPS;
+
 // Error types
 extern NSString * const ERROR_UNSUPPORTED_TYPE;
 extern NSString * const ERROR_ONLOADING;
@@ -21,5 +25,6 @@ extern NSString * const ERROR_INVALID_REACT_TAG;
 
 // Error messages
 extern NSString * const ERROR_MESSAGE_KEY;
+extern NSString * const ERROR_MESSAGE_TITLE;
 extern NSString * const ERROR_MESSAGE_BASE64_NIL;
 extern NSString * const ERROR_MESSAGE_FILENOTFOUND;

--- a/ReactNativeViewPDF/PDFConstants.m
+++ b/ReactNativeViewPDF/PDFConstants.m
@@ -13,6 +13,10 @@ NSString *const URL_PROPS_METHOD_KEY = @"method";
 NSString *const URL_PROPS_HEADERS_KEY = @"headers";
 NSString *const URL_PROPS_BODY_KEY = @"body";
 
+// Supported protocols
+NSString *const HTTP = @"http";
+NSString *const HTTPS = @"https";
+
 // Error types
 NSString *const ERROR_UNSUPPORTED_TYPE = @"Unsupported resourceType";
 NSString *const ERROR_ONLOADING = @"Error occured while loading content in webview";
@@ -20,6 +24,7 @@ NSString *const ERROR_REQUIRED_INPUT_NOT_SET = @"Validation failed. Confirm reso
 NSString *const ERROR_INVALID_REACT_TAG = @"Invalid react tag";
 
 // Error messages
-NSString *const ERROR_MESSAGE_KEY = @"errorMessage";
+NSString *const ERROR_MESSAGE_KEY = @"message";
+NSString *const ERROR_MESSAGE_TITLE = @"title";
 NSString *const ERROR_MESSAGE_BASE64_NIL = @"Converted Base64 data is nil";
 NSString *const ERROR_MESSAGE_FILENOTFOUND = @"PDF file not found";

--- a/android/src/main/java/com/rumax/reactnative/pdfviewer/PDFView.java
+++ b/android/src/main/java/com/rumax/reactnative/pdfviewer/PDFView.java
@@ -27,9 +27,9 @@ import java.io.IOException;
 import java.io.InputStream;
 
 public class PDFView extends com.github.barteksc.pdfviewer.PDFView implements
-        OnLoadCompleteListener,
         OnErrorListener,
-        OnPageChangeListener {
+        OnPageChangeListener,
+        OnLoadCompleteListener {
     public final static String EVENT_ON_LOAD = "onLoad";
     public final static String EVENT_ON_ERROR = "onError";
     public final static String EVENT_ON_PAGE_CHANGED = "onPageChanged";
@@ -143,14 +143,13 @@ public class PDFView extends com.github.barteksc.pdfviewer.PDFView implements
 
         downloadTask = new AsyncDownload(resource, downloadedFile, urlProps, new AsyncDownload.TaskCompleted() {
             @Override
-            public void downloadTaskCompleted() {
-                renderFromFile(downloadedFile.getAbsolutePath());
-            }
-
-            @Override
-            public void downloadTaskFailed(IOException e) {
-                cleanDownloadedFile();
-                onError(e);
+            public void onComplete(Exception ex) {
+                if (ex == null) {
+                    renderFromFile(downloadedFile.getAbsolutePath());
+                } else {
+                    cleanDownloadedFile();
+                    onError(ex);
+                }
             }
         });
         downloadTask.execute();

--- a/demo/package.json
+++ b/demo/package.json
@@ -10,7 +10,7 @@
     "react-native": "0.57.4",
     "react-native-dropdownalert": "^3.7.0",
     "react-native-loading-spinner-overlay": "^1.0.1",
-    "react-native-view-pdf": "0.6.0"
+    "react-native-view-pdf": "0.6.1"
   },
   "devDependencies": {
     "babel-eslint": "^9.0.0",

--- a/demo/src/App.js
+++ b/demo/src/App.js
@@ -16,7 +16,7 @@ import Button from './Button';
 import pkg from '../package.json';
 
 type StateType = {
-  activeButton?: 'assets' | 'file' | 'url' | 'post' | 'base64' | 'error',
+  activeButton?: 'assets' | 'file' | 'url' | 'post' | 'base64' | 'errorData' | 'errorProtocol',
   resource?: Resource,
   spinner: boolean,
   canReload?: boolean,
@@ -114,8 +114,17 @@ export default class App extends React.Component<*, StateType> {
 
   dataWithError = () => {
     this.setState({
-      activeButton: 'error',
-      resource: resources.invalid,
+      activeButton: 'errorData',
+      resource: resources.invalidData,
+      spinner: true,
+    });
+  }
+
+
+  protocolWithError = () => {
+    this.setState({
+      activeButton: 'errorProtocol',
+      resource: resources.invalidProtocol,
       spinner: true,
     });
   }
@@ -198,8 +207,8 @@ export default class App extends React.Component<*, StateType> {
           <Button active={activeButton === 'url'} onPress={this.setUrl} title="Url" />
           <Button active={activeButton === 'base64'} onPress={this.setBase64} title="Base64" />
           <Button active={activeButton === 'file'} onPress={this.setFile} title="File" />
-          <Button active={activeButton === 'error'} onPress={this.dataWithError} title="Error" />
-          <Button active={activeButton === 'reset'} onPress={this.resetData} title="Reset" />
+          <Button active={activeButton === 'assets'} onPress={this.setFileAssets} title="Assets" />
+          <Button active={activeButton === 'post'} onPress={this.setUrlPost} title="Url Post" />
         </View>
         <PdfContent
           resource={state.resource}
@@ -209,8 +218,8 @@ export default class App extends React.Component<*, StateType> {
           onPageChanged={this.handlePageChanged}
         />
         <View style={styles.tabs}>
-          <Button active={activeButton === 'post'} onPress={this.setUrlPost} title="Url Post" />
-          <Button active={activeButton === 'assets'} onPress={this.setFileAssets} title="Assets" />
+          <Button active={activeButton === 'errorData'} onPress={this.dataWithError} title="Error data" />
+          <Button active={activeButton === 'errorProtocol'} onPress={this.protocolWithError} title="Error protocol" />
           <Button active={activeButton === 'reset'} onPress={this.resetData} title="Reset" />
         </View>
         {state.canReload && (

--- a/demo/src/resources.js
+++ b/demo/src/resources.js
@@ -41,9 +41,13 @@ const resources: {[key: string]: Resource } = {
     resource: base64Data.document,
     resourceType: 'base64',
   },
-  invalid: {
+  invalidData: {
     resource: '**invalid base 64**',
     resourceType: 'base64',
+  },
+  invalidProtocol: {
+    resource: 'file:/test-pdf.pdf',
+    resourceType: 'url',
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-view-pdf",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-view-pdf",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "React native Pdf viewer implementation",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
### Description of changes
Check and handle protocol errors
    
    - Support only http and https protocols for url type
    - Align errors on iOS and android (thrown error should contain message field)
    - One callback onComplete for AsyncDownload

Refactor demo project
     - Protocol error case
     - Move error states and reset to bottom of the page and keep data on top

Closed #90 

### I did Exploratory testing:
- [x] android
- [x] ios

### Can it be published to NPM?
- [ ] ~~Breaking change~~
- [ ] Documentation is updated
