### PR TITLE
Add render pdf from documents directory to demo project

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ import PDFView from 'react-native-view-pdf';
 // import PDFView from 'react-native-view-pdf/lib/index';
 
 const resources = {
-  file: Platform.OS === 'ios' ? 'test-pdf.pdf' : '/sdcard/Download/test-pdf.pdf',
+  file: Platform.OS === 'ios' ? 'downloadedDocument.pdf' : '/sdcard/Download/downloadedDocument.pdf',
   url: 'https://www.ets.org/Media/Tests/TOEFL/pdf/SampleQuestions.pdf',
   base64: 'JVBERi0xLjMKJcfs...',
 };
@@ -194,7 +194,12 @@ section from react native or [Request App Permissions ](https://developer.androi
 documentation. [Demo](https://github.com/rumax/react-native-PDFView/tree/master/demo)
 project provides an example how to implement it using Java, check the [MainActivity.java](https://github.com/rumax/react-native-PDFView/blob/b84913df174d3b638d2d820a66ed4e6605d56860/demo/android/app/src/main/java/com/demo/MainActivity.java#L12) and [AndroidManifest.xml](https://github.com/rumax/react-native-PDFView/blob/b84913df174d3b638d2d820a66ed4e6605d56860/demo/android/app/src/main/AndroidManifest.xml#L6) files.
 
-Before trying `file` type in [demo project](https://github.com/rumax/react-native-PDFView/tree/master/demo), open `sdcard/Download` folder in `Device File Explorer` and store the `test-pdf.pdf` document that you want to render (you can find an example in demo/ios/test-pdf.pdf).
+Before trying `file` type in [demo project](https://github.com/rumax/react-native-PDFView/tree/master/demo), open `sdcard/Download` folder in `Device File Explorer` and store some `downloadedDocument.pdf` document that you want to render.
+
+On iOS, using resource `file` will make the component lookup in two places. First, it will attempt to locate the file in the Bundle. If it cannot locate it there, it will search the Documents directory. For more information on the iOS filesystem access at runtime of an application please refer [the official documentation](https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html).
+Note here that the resource will always need to be a relative path from the Documents directory for example and also do NOT put the scheme in the path (so no `file://.....`).
+
+You can find an example of both usage of the Bundle and Documents directory for rendering a pdf from `file` on iOS in the demo project.
 
 In [demo](https://github.com/rumax/react-native-PDFView/tree/master/demo) project you can also run the simple server to serve PDF file. To do this navigate to `demo/utils/` and start the server
 `node server.js`. (*Do not forget to set proper IP adress of the server

--- a/ReactNativeViewPDF/PDFView.m
+++ b/ReactNativeViewPDF/PDFView.m
@@ -85,10 +85,9 @@
     NSURL *URL = [NSURL URLWithString: _resource];
     NSString *scheme = URL.scheme;
 
-    if ([HTTP caseInsensitiveCompare:scheme] != NSOrderedSame &&
-        [HTTPS caseInsensitiveCompare:scheme] != NSOrderedSame) {
-        NSString *errorMessage = [NSString stringWithFormat:@"Protocol %@ is not supported", scheme];
-        [self throwError: errorMessage withMessage: errorMessage];
+    if ([HTTP caseInsensitiveCompare: scheme] != NSOrderedSame &&
+        [HTTPS caseInsensitiveCompare: scheme] != NSOrderedSame) {
+        [self throwError: ERROR_ONLOADING withMessage: [NSString stringWithFormat:@"Protocol %@ is not supported", scheme]];
     }
 
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL: URL
@@ -156,7 +155,7 @@
     if(![[NSFileManager defaultManager] fileExistsAtPath: filePath]) {
         return nil;
     }
-    return [NSURL fileURLWithPath:filePath];
+    return [NSURL fileURLWithPath: filePath];
 }
 
 - (BOOL)isRequiredInputSet {

--- a/demo/ios/demo/AppDelegate.m
+++ b/demo/ios/demo/AppDelegate.m
@@ -29,7 +29,18 @@
   rootViewController.view = rootView;
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
+  [self writePDFToDocumentsDir];
   return YES;
+}
+
+-(void)writePDFToDocumentsDir
+{
+  NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+  NSString *documentDirectory = [paths objectAtIndex: 0];
+  NSString *finalPath = [documentDirectory stringByAppendingPathComponent: [NSString stringWithFormat: @"downloadedDocument.pdf"]];
+  
+  NSData *datapdf = [NSData dataWithContentsOfURL: [NSURL fileURLWithPath: [[NSBundle mainBundle] pathForResource: @"test-pdf" ofType: @"pdf"]]];
+  [datapdf writeToFile: finalPath atomically: YES];
 }
 
 @end

--- a/demo/src/resources.js
+++ b/demo/src/resources.js
@@ -16,7 +16,7 @@ const resources: {[key: string]: Resource } = {
     resourceType: 'file',
   },
   file: {
-    resource: Platform.OS === 'ios' ? 'test-pdf.pdf' : '/sdcard/Download/test-pdf.pdf',
+    resource: `${Platform.OS === 'ios' ? '' : '/sdcard/Download/'}downloadedDocument.pdf`,
     resourceType: 'file',
   },
   url: {


### PR DESCRIPTION
- write file at app start up to documents directory
- change resource in JS to read from documents directory on iOS
- update readme with more info on render pdf from filesystem on iOS

### Description of changes

### I did Exploratory testing:
- [ ] android
- [x] ios

### Can it be published to NPM?
- [ ] Breaking change
- [x] Documentation is updated
