### PR TITLE
fileFrom iOS parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Name | Android | iOS | Description
 ---- | ------- | --- | -----------
 resource | ✓ | ✓ | A resource to render. It's possible to render PDF from `file`, `url` or `base64`
 resourceType | ✓ | ✓ | Should correspond to resource and can be: `file`, `url` or `base64`
+fileFrom | ✗ | ✓ | *iOS ONLY:* In case if `resourceType` is set to `file`, there are different way to search for it on [iOS file system](https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html). Currently `Documents` and `app’s bundle` are supported. 
 onLoad | ✓ | ✓ | Callback that is triggered when loading is completed
 onError | ✓ | ✓ | Callback that is triggered when loading has failed. And error is provided as a function parameter
 style | ✓ | ✓ | A [style](https://facebook.github.io/react-native/docs/style)

--- a/ReactNativeViewPDF/PDFView.h
+++ b/ReactNativeViewPDF/PDFView.h
@@ -6,6 +6,7 @@
 
 @property (nonatomic, copy) NSString *resource;
 @property (nonatomic, copy) NSString *resourceType;
+@property (nonatomic, copy) NSString *fileFrom;
 @property (nonatomic, copy) NSString *textEncoding;
 @property (nonatomic, copy) NSDictionary *urlProps;
 @property (nonatomic) NSTimeInterval fadeInDuration;

--- a/ReactNativeViewPDF/PDFViewManager.m
+++ b/ReactNativeViewPDF/PDFViewManager.m
@@ -13,6 +13,10 @@ RCT_CUSTOM_VIEW_PROPERTY(resourceType, NSString, PDFView) {
     [view setResourceType: json ? [RCTConvert NSString: json] : nil];
 }
 
+RCT_CUSTOM_VIEW_PROPERTY(fileFrom, NSString, PDFView) {
+    [view setFileFrom: json ? [RCTConvert NSString: json] : nil];
+}
+
 RCT_CUSTOM_VIEW_PROPERTY(textEncoding, NSString, PDFView) {
     [view setTextEncoding: json ? [RCTConvert NSString: json] : UTF_8];
 }

--- a/android/src/main/java/com/rumax/reactnative/pdfviewer/PDFViewManager.java
+++ b/android/src/main/java/com/rumax/reactnative/pdfviewer/PDFViewManager.java
@@ -78,6 +78,11 @@ public class PDFViewManager extends SimpleViewManager<PDFView> {
         pdfView.setResourceType(resourceType);
     }
 
+    @ReactProp(name = "fileFrom")
+    public void setFileFrom(PDFView pdfView, String fileFrom) {
+        // iOS specific, ignoring
+    }
+
     @ReactProp(name = "textEncoding")
     public void setTextEncoding(PDFView pdfView, String textEncoding) {
     }

--- a/demo/package.json
+++ b/demo/package.json
@@ -10,7 +10,7 @@
     "react-native": "0.57.7",
     "react-native-dropdownalert": "^3.7.0",
     "react-native-loading-spinner-overlay": "^1.0.1",
-    "react-native-view-pdf": "^0.6.3"
+    "react-native-view-pdf": "^0.6.4"
   },
   "devDependencies": {
     "babel-jest": "23.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-view-pdf",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-view-pdf",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "React native Pdf viewer implementation",
   "main": "src/index.js",
   "scripts": {

--- a/src/RNPDFView.js
+++ b/src/RNPDFView.js
@@ -38,6 +38,13 @@ const componentInterface = {
     resourceType: PropTypes.string,
 
     /**
+     * iOS file location. Can be one of:
+     *   - "bundle"
+     *   - "documentsDirectory"
+     */
+    fileFrom: PropTypes.string,
+
+    /**
      * Extended props for "url" resource type
      */
     urlProps: {

--- a/src/index.js
+++ b/src/index.js
@@ -64,6 +64,13 @@ type Props = {
    */
   resourceType: 'url' | 'base64' | 'file',
 
+  /**
+   * iOS file location. Can be one of:
+   *   - "bundle"
+   *   - "documentsDirectory"
+   */
+  fileFrom?: 'bundle' | 'documentsDirectory',
+
   urlProps?: UrlProps,
 
   /**


### PR DESCRIPTION
- Make it possible to define the exact location of the file on iOS file system
- Support Documents and app bundle locations
- Default is still searching

### Description of changes
- New `fileFrom` property for iOS
- Make it possible to implement https://github.com/rumax/react-native-PDFView/issues/97

### I did Exploratory testing:
- [x] android
- [x] ios

### Can it be published to NPM?
- [x] ~~Breaking change~~
- [x] Documentation is updated
