### PR TITLE
:lollipop: fix android build gradle for RN 0.59.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,8 @@ repositories {
 }
 
 dependencies {
-    compileOnly "com.facebook.react:react-native:+"
+    compileOnly('com.facebook.react:react-native:+') {
+        exclude group: 'com.android.support'
+    }
     implementation "com.github.barteksc:android-pdf-viewer:${safeExtGet("pdfViewer", "2.8.2")}"
 }


### PR DESCRIPTION
### Description of changes
The current build gradle setup fails for react native 59, this small change fixes that.