### PR TITLE
Use supportLibVersion (fix dependency issues with RN 0.59.x)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,10 @@ android {
 
 dependencies {
     def supportLibVersion = safeExtGet('supportLibVersion', _defaults.supportLibVersion)
+
+    //noinspection GradleDynamicVersion
     compileOnly "com.facebook.react:react-native:+"
+
     implementation 'com.github.barteksc:android-pdf-viewer:2.8.2'
     implementation "com.android.support:appcompat-v7:$supportLibVersion"
     implementation "com.android.support:support-v4:$supportLibVersion"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,29 +1,38 @@
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
+def _defaults = {
+    buildToolsVersion = "28.0.3"
+    compileSdkVersion = 28
+    minSdkVersion = 21
+    supportLibVersion = "28.0.0"
+    targetSdkVersion = 28
+}
 
 apply plugin: 'com.android.library'
 
+
 android {
-    compileSdkVersion safeExtGet('compileSdkVersion', 26)
-    buildToolsVersion safeExtGet('buildToolsVersion', '25.0.3')
+    compileSdkVersion safeExtGet('compileSdkVersion', _defaults.compileSdkVersion)
+    buildToolsVersion safeExtGet('buildToolsVersion', _defaults.buildToolsVersion)
 
     defaultConfig {
-        minSdkVersion safeExtGet('minSdkVersion', 21)
-        targetSdkVersion safeExtGet('targetSdkVersion', 25)
+        minSdkVersion safeExtGet('minSdkVersion', _defaults.minSdkVersion)
+        targetSdkVersion safeExtGet('targetSdkVersion', _defaults.targetSdkVersion)
     }
     lintOptions {
         abortOnError false
     }
-}
-
-repositories {
-    mavenCentral()
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {
-    compileOnly('com.facebook.react:react-native:+') {
-        exclude group: 'com.android.support'
-    }
-    implementation "com.github.barteksc:android-pdf-viewer:${safeExtGet("pdfViewer", "2.8.2")}"
+    def supportLibVersion = safeExtGet('supportLibVersion', _defaults.supportLibVersion)
+    compileOnly "com.facebook.react:react-native:+"
+    implementation 'com.github.barteksc:android-pdf-viewer:2.8.2'
+    implementation "com.android.support:appcompat-v7:$supportLibVersion"
+    implementation "com.android.support:support-v4:$supportLibVersion"
 }

--- a/demo/android/app/build.gradle
+++ b/demo/android/app/build.gradle
@@ -88,7 +88,7 @@ dependencies {
     implementation project(':react-native-view-pdf')
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
-    implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation('com.facebook.react:react-native:0.59.8') { force = true } // From node_modules
 }
 
 // Run this once to be able to run the application with BUCK

--- a/demo/android/app/src/main/AndroidManifest.xml
+++ b/demo/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.demo">
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.demo">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
@@ -10,7 +11,8 @@
       android:icon="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
-      android:theme="@style/AppTheme">
+      android:theme="@style/AppTheme"
+        tools:ignore="GoogleAppIndexingWarning">
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"

--- a/demo/android/build.gradle
+++ b/demo/android/build.gradle
@@ -3,10 +3,10 @@
 buildscript {
     ext {
         buildToolsVersion = "28.0.3"
-        minSdkVersion = 21
         compileSdkVersion = 28
-        targetSdkVersion = 28
+        minSdkVersion = 21
         supportLibVersion = "28.0.0"
+        targetSdkVersion = 28
 
         pdfViewer = "3.1.0-beta.1"
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-view-pdf",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "React native Pdf viewer implementation",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
### Description of changes

Fixes Android issue with RN 0.59.x

Fixes #121

- Use supportLibVersion (fix dependency issues with RN 0.59.x).
- Use defaults for gradle
- Fix gradle warnings

### I did Exploratory testing:
- [x] android
- [x] ~~ios~~

### Can it be published to NPM?
- [x] ~~Breaking change~~
- [x] ~~Documentation is updated~~
