### PR TITLE
Update index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Uilque Messias <https://github.com/uqmessias>
 // TypeScript Version: 3.2.1
 
-import React from "react";
+import * as React from "react";
 import { StyleProp, ViewStyle } from "react-native";
 
 export interface PDFViewUrlProps {


### PR DESCRIPTION
Usage:
```
import PDFView from "react-native-view-pdf";
//...

<PDFView fadeInDuration={250.0} style={styles.container} resource={url} resourceType={"url"} />
```

Getting following error in typescript project:
`Error:(20, 13) TS2607: JSX element class does not support attributes because it does not have a 'props' property.`

<img width="1008" alt="Screenshot 2019-08-06 at 14 41 16" src="https://user-images.githubusercontent.com/42858722/62540621-512c4780-b858-11e9-8c8c-3488a181d28a.png">



Typescript can not resolve React.Component because of wrong import in `index.d.ts` and therefore this error will be thrown.

### Description of changes

### I did Exploratory testing:
- [ ] android
- [ ] ios
- [x] typescript

### Can it be published to NPM?
- [ ] Breaking change
- [ ] Documentation is updated
