### PR TITLE
:apple: Add file load from /Library and /tmp folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Name | Android | iOS | Description
 ---- | ------- | --- | -----------
 resource | ✓ | ✓ | A resource to render. It's possible to render PDF from `file`, `url` or `base64`
 resourceType | ✓ | ✓ | Should correspond to resource and can be: `file`, `url` or `base64`
-fileFrom | ✗ | ✓ | *iOS ONLY:* In case if `resourceType` is set to `file`, there are different way to search for it on [iOS file system](https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html). Currently `Documents` and `app’s bundle` are supported.
+fileFrom | ✗ | ✓ | *iOS ONLY:* In case if `resourceType` is set to `file`, there are different way to search for it on [iOS file system](https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html). Currently `documentsDirectory`, `libraryDirectory`, `tempDirectory` and `bundle` are supported.
 onLoad | ✓ | ✓ | Callback that is triggered when loading is completed
 onError | ✓ | ✓ | Callback that is triggered when loading has failed. And error is provided as a function parameter
 style | ✓ | ✓ | A [style](https://facebook.github.io/react-native/docs/style)
@@ -195,7 +195,7 @@ project provides an example how to implement it using Java, check the [MainActiv
 
 Before trying `file` type in [demo project](https://github.com/rumax/react-native-PDFView/tree/master/demo), open `sdcard/Download` folder in `Device File Explorer` and store some `downloadedDocument.pdf` document that you want to render.
 
-On iOS, using resource `file` will make the component lookup in two places. First, it will attempt to locate the file in the Bundle. If it cannot locate it there, it will search the Documents directory. For more information on the iOS filesystem access at runtime of an application please refer [the official documentation](https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html).
+On iOS, when using resource `file` you can specify where to look for the file with `fileFrom`. If you do not pass any value, the component will lookup in two places. First, it will attempt to locate the file in the Bundle. If it cannot locate it there, it will search the Documents directory. For more information on the iOS filesystem access at runtime of an application please refer [the official documentation](https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html).
 Note here that the resource will always need to be a relative path from the Documents directory for example and also do NOT put the scheme in the path (so no `file://.....`).
 
 You can find an example of both usage of the Bundle and Documents directory for rendering a pdf from `file` on iOS in the demo project.

--- a/ReactNativeViewPDF/RNPDFView.m
+++ b/ReactNativeViewPDF/RNPDFView.m
@@ -113,15 +113,15 @@
     if ([currentFileFrom isEqualToString:@"bundle"]) {
         url = [self fileFromBundleURL];
     } else if ([currentFileFrom isEqualToString:@"documentsDirectory"]) {
-		url = [self fileFromDirectoryURL:NSDocumentDirectory];
-	} else if ([currentFileFrom isEqualToString:@"libraryDirectory"]) {
-		url = [self fileFromDirectoryURL:NSLibraryDirectory];
-	} else if ([currentFileFrom isEqualToString:@"tempDirectory"]) {
-		url = [self fileFromDirectoryPath:NSTemporaryDirectory()];
-	} else { // default is search
+        url = [self fileFromDirectoryURL:NSDocumentDirectory];
+    } else if ([currentFileFrom isEqualToString:@"libraryDirectory"]) {
+        url = [self fileFromDirectoryURL:NSLibraryDirectory];
+    } else if ([currentFileFrom isEqualToString:@"tempDirectory"]) {
+        url = [self fileFromDirectoryPath:NSTemporaryDirectory()];
+    } else { // default is search
         url = [self fileFromBundleURL];
         if (url == nil) {
-			// default directory is Documents
+            // default directory is Documents
             url = [self fileFromDirectoryURL:NSDocumentDirectory];
         }
     }
@@ -204,14 +204,14 @@
 }
 
 - (NSURL *)fileFromDirectoryPath:(NSString *)directoryPath {
-	if (directoryPath == nil) {
-		return nil;
-	}
-	NSString *filePath = [directoryPath stringByAppendingPathComponent: _resource];
-	if(![[NSFileManager defaultManager] fileExistsAtPath: filePath]) {
-		return nil;
-	}
-	return [NSURL fileURLWithPath: filePath];
+    if (directoryPath == nil) {
+        return nil;
+    }
+    NSString *filePath = [directoryPath stringByAppendingPathComponent: _resource];
+    if(![[NSFileManager defaultManager] fileExistsAtPath: filePath]) {
+        return nil;
+    }
+    return [NSURL fileURLWithPath: filePath];
 }
 
 - (BOOL)isRequiredInputSet {

--- a/ReactNativeViewPDF/RNPDFView.m
+++ b/ReactNativeViewPDF/RNPDFView.m
@@ -113,11 +113,16 @@
     if ([currentFileFrom isEqualToString:@"bundle"]) {
         url = [self fileFromBundleURL];
     } else if ([currentFileFrom isEqualToString:@"documentsDirectory"]) {
-        url = [self fileFromDocumentsDirectoryURL];
-    } else { // default is search
+		url = [self fileFromDirectoryURL:NSDocumentDirectory];
+	} else if ([currentFileFrom isEqualToString:@"libraryDirectory"]) {
+		url = [self fileFromDirectoryURL:NSLibraryDirectory];
+	} else if ([currentFileFrom isEqualToString:@"tempDirectory"]) {
+		url = [self fileFromDirectoryPath:NSTemporaryDirectory()];
+	} else { // default is search
         url = [self fileFromBundleURL];
         if (url == nil) {
-            url = [self fileFromDocumentsDirectoryURL];
+			// default directory is Documents
+            url = [self fileFromDirectoryURL:NSDocumentDirectory];
         }
     }
 
@@ -192,16 +197,21 @@
     }
 }
 
-- (NSURL *)fileFromDocumentsDirectoryURL {
-    NSString *documentsDirectory = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) lastObject];
-    if (documentsDirectory == nil) {
-        return nil;
-    }
-    NSString *filePath = [documentsDirectory stringByAppendingPathComponent: _resource];
-    if(![[NSFileManager defaultManager] fileExistsAtPath: filePath]) {
-        return nil;
-    }
-    return [NSURL fileURLWithPath: filePath];
+- (NSURL *)fileFromDirectoryURL:(NSSearchPathDirectory)directory {
+    NSString *directoryPath = [NSSearchPathForDirectoriesInDomains(directory, NSUserDomainMask, YES) lastObject];
+
+    return [self fileFromDirectoryPath:directoryPath];
+}
+
+- (NSURL *)fileFromDirectoryPath:(NSString *)directoryPath {
+	if (directoryPath == nil) {
+		return nil;
+	}
+	NSString *filePath = [directoryPath stringByAppendingPathComponent: _resource];
+	if(![[NSFileManager defaultManager] fileExistsAtPath: filePath]) {
+		return nil;
+	}
+	return [NSURL fileURLWithPath: filePath];
 }
 
 - (BOOL)isRequiredInputSet {

--- a/index.d.ts
+++ b/index.d.ts
@@ -74,8 +74,10 @@ interface PDFViewProps {
    * iOS file location. Can be one of:
    *   - "bundle"
    *   - "documentsDirectory"
+   *   - "libraryDirectory"
+   *   - "tempDirectory"
    */
-  fileFrom?: "bundle" | "documentsDirectory";
+  fileFrom?: "bundle" | "documentsDirectory" | "libraryDirectory" | "tempDirectory";
 
   urlProps?: PDFViewUrlProps;
 

--- a/src/RNPDFView.js
+++ b/src/RNPDFView.js
@@ -46,6 +46,8 @@ const componentInterface = {
      * iOS file location. Can be one of:
      *   - "bundle"
      *   - "documentsDirectory"
+     *   - "libraryDirectory"
+     *   - "tempDirectory"
      */
     fileFrom: PropTypes.string,
 

--- a/src/index.js
+++ b/src/index.js
@@ -77,8 +77,10 @@ type PropsType = {
    * iOS file location. Can be one of:
    *   - "bundle"
    *   - "documentsDirectory"
+   *   - "libraryDirectory"
+   *   - "tempDirectory"
    */
-  fileFrom?: 'bundle' | 'documentsDirectory',
+  fileFrom?: 'bundle' | 'documentsDirectory' | 'libraryDirectory' | 'tempDirectory',
 
   urlProps?: UrlPropsType,
 


### PR DESCRIPTION
### Description of changes
This pull request adds the functionality to load files from /Library and /tmp folder on iOS by extending the `fileFrom` property and editing the iOS methods to find the absolute paths.

### I did Exploratory testing:
- [x] ~~android~~
- [x] ios

### Can it be published to NPM?
- [x] ~~Breaking change~~
- [x] Documentation is updated
