### PR TITLE
Add enableAnnotations prop to render annotations on android

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ onLoad | ✓ | ✓ | Callback that is triggered when loading is completed
 onError | ✓ | ✓ | Callback that is triggered when loading has failed. And error is provided as a function parameter
 style | ✓ | ✓ | A [style](https://facebook.github.io/react-native/docs/style)
 fadeInDuration | ✓ | ✓ | Fade in duration (in ms, defaults to 0.0) to smoothly fade the webview into view when pdf loading is completed
+enableAnnotations | ✓ | ✗ | *Android ONLY:* Boolean to enable Android view annotations (default is false).
 urlProps | ✓ | ✓ | Extended properties for `url` type that allows to specify HTTP Method, HTTP headers and HTTP body
 onPageChanged | ✓ | ✗ | Callback that is invoked when page is changed. Provides `active page` and `total pages` information
 onScrolled | ✓ | ✓ | Callback that is invoked when PDF is scrolled. Provides `offset` value in a range between 0 and 1. *Currently only 0 and 1 are supported*.

--- a/android/src/main/java/com/rumax/reactnative/pdfviewer/PDFView.java
+++ b/android/src/main/java/com/rumax/reactnative/pdfviewer/PDFView.java
@@ -258,6 +258,10 @@ public class PDFView extends com.github.barteksc.pdfviewer.PDFView implements
         this.fadeInDuration = duration;
     }
 
+    public void setEnableAnnotations(boolean enableAnnotations) {
+        this.enableAnnotations = enableAnnotations;
+    }
+
     public void reload() {
         sourceChanged = true;
         render();

--- a/android/src/main/java/com/rumax/reactnative/pdfviewer/PDFView.java
+++ b/android/src/main/java/com/rumax/reactnative/pdfviewer/PDFView.java
@@ -45,6 +45,7 @@ public class PDFView extends com.github.barteksc.pdfviewer.PDFView implements
     private boolean sourceChanged = true;
     private ReadableMap urlProps;
     private int fadeInDuration = 0;
+    private boolean enableAnnotations = false;
     private float lastPositionOffset = 0;
 
     public PDFView(ThemedReactContext context) {
@@ -117,6 +118,7 @@ public class PDFView extends com.github.barteksc.pdfviewer.PDFView implements
                 .onPageChange(this)
                 .onPageScroll(this)
                 .spacing(10)
+                .enableAnnotationRendering(enableAnnotations)
                 .load();
         sourceChanged = false;
     }

--- a/android/src/main/java/com/rumax/reactnative/pdfviewer/PDFViewManager.java
+++ b/android/src/main/java/com/rumax/reactnative/pdfviewer/PDFViewManager.java
@@ -105,6 +105,11 @@ public class PDFViewManager extends SimpleViewManager<PDFView> {
         pdfView.setFadeInDuration(duration);
     }
 
+    @ReactProp(name = "enableAnnotations")
+    public void setEnableAnnotations(PDFView pdfView, boolean enableAnnotations) {
+        pdfView.setEnableAnnotations(enableAnnotations);
+    }
+
     @Override
     public void onAfterUpdateTransaction(PDFView pdfView) {
         super.onAfterUpdateTransaction(pdfView);

--- a/src/RNPDFView.js
+++ b/src/RNPDFView.js
@@ -86,6 +86,13 @@ const componentInterface = {
      *   - 0.0, default
      */
     fadeInDuration: PropTypes.number,
+
+    /**
+     * A Boolean value. Enables annotations view on Android
+     *   - false, default
+     */
+    enableAnnotations: PropTypes.bool,
+
     ...ViewPropTypes,
   },
 };

--- a/src/index.js
+++ b/src/index.js
@@ -96,6 +96,12 @@ type PropsType = {
    *   - 0.0, default
    */
   fadeInDuration?: number,
+
+  /**
+   * A Boolean value. Enables annotations view on Android
+   *   - false, default
+   */
+  enableAnnotations?: boolean,
 };
 
 class PDFView extends React.Component<PropsType, *> {


### PR DESCRIPTION
### Description of changes
Add enableAnnotations boolean prop to render annotations on android

### I did Exploratory testing:
- [x] android
- [ ] ios

### Can it be published to NPM?
- [ ] Breaking change
- [x] Documentation is updated
