### PR TITLE
Support file protocol in url resource

### DIFF
--- a/ReactNativeViewPDF/RNPDFConstants.h
+++ b/ReactNativeViewPDF/RNPDFConstants.h
@@ -14,8 +14,9 @@ extern NSString * const URL_PROPS_HEADERS_KEY;
 extern NSString * const URL_PROPS_BODY_KEY;
 
 // Supported protocols
-extern NSString * const HTTP;
-extern NSString * const HTTPS;
+extern NSString * const HTTP_PROTOCOL;
+extern NSString * const HTTPS_PROTOCOL;
+extern NSString * const FILE_PROTOCOL;
 
 // Error types
 extern NSString * const ERROR_UNSUPPORTED_TYPE;

--- a/ReactNativeViewPDF/RNPDFConstants.m
+++ b/ReactNativeViewPDF/RNPDFConstants.m
@@ -14,8 +14,9 @@ NSString *const URL_PROPS_HEADERS_KEY = @"headers";
 NSString *const URL_PROPS_BODY_KEY = @"body";
 
 // Supported protocols
-NSString *const HTTP = @"http";
-NSString *const HTTPS = @"https";
+NSString *const HTTP_PROTOCOL = @"http";
+NSString *const HTTPS_PROTOCOL = @"https";
+NSString *const FILE_PROTOCOL = @"file";
 
 // Error types
 NSString *const ERROR_UNSUPPORTED_TYPE = @"Unsupported resourceType";

--- a/ReactNativeViewPDF/RNPDFView.m
+++ b/ReactNativeViewPDF/RNPDFView.m
@@ -88,7 +88,10 @@
     ignoreScrollEvent = true;
 
     if ([self isURLResource]) {
-        [webview loadRequest: [self createRequest]];
+        NSURLRequest *request = [self createRequest];
+        if (request) {
+            [webview loadRequest: request];
+        }
     } else if ([self isFileResource]) {
         NSURL *fileURL = [self getFileURL];
         if (fileURL == nil) {
@@ -133,9 +136,11 @@
     NSURL *URL = [NSURL URLWithString: _resource];
     NSString *scheme = URL.scheme;
 
-    if ([HTTP caseInsensitiveCompare: scheme] != NSOrderedSame &&
-        [HTTPS caseInsensitiveCompare: scheme] != NSOrderedSame) {
+    if ([HTTP_PROTOCOL caseInsensitiveCompare: scheme] != NSOrderedSame &&
+        [HTTPS_PROTOCOL caseInsensitiveCompare: scheme] != NSOrderedSame &&
+        [FILE_PROTOCOL caseInsensitiveCompare: scheme] != NSOrderedSame) {
         [self throwError: ERROR_ONLOADING withMessage: [NSString stringWithFormat:@"Protocol %@ is not supported", scheme]];
+        return nil;
     }
 
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL: URL


### PR DESCRIPTION
### Description of changes

I want to support viewing pdfs selected from `UIDocumentPickerViewController` on iOS. The url returned is using the `file` protocol and can be opened by webview. The current behavior is the pdf is loaded correctly, however the error handler is called due to unsupported protocols.

1. Add `file` to the list of supported protocols so error handler is not called on successful load.
2. Renaming other protocol constants to be consistent to `FILE_PROTOCOL`, it's called that since `FILE` is defined elsewhere.
3. If it's not a supported protocol, do not create the request and load it in webview.

### I did Exploratory testing:
- [ ] android
- [x] ios

### Can it be published to NPM?
- [ ] Breaking change
- [ ] Documentation is updated
