### PR TITLE
Support android content resolver uri

### DIFF
--- a/android/src/main/java/com/rumax/reactnative/pdfviewer/PDFView.java
+++ b/android/src/main/java/com/rumax/reactnative/pdfviewer/PDFView.java
@@ -160,7 +160,7 @@ public class PDFView extends com.github.barteksc.pdfviewer.PDFView implements
             return;
         }
 
-        downloadTask = new AsyncDownload(resource, downloadedFile, urlProps, new AsyncDownload.TaskCompleted() {
+        downloadTask = new AsyncDownload(context, resource, downloadedFile, urlProps, new AsyncDownload.TaskCompleted() {
             @Override
             public void onComplete(Exception ex) {
                 if (ex == null) {


### PR DESCRIPTION
### Description of changes

Similar to https://github.com/rumax/react-native-PDFView/pull/168, I want to be able to view the PDF file picked by `Intent.ACTION_GET_CONTENT` on Android. (I am trying to make this work nicely with https://www.npmjs.com/package/react-native-document-picker on both platforms.)

In that case I get back an `Uri` that needs to be opened using the content resolver. I thought about whether to fit this into `renderFromUrl` or `renderFromFile`. I decided on `renderFromUrl` because the intent can return a local file as well as a file stored in google drive that's not downloaded yet, in that case trying to get a `FileInputStream` may not work.

### I did Exploratory testing:
- [x] android
- [ ] ios

### Can it be published to NPM?
- [ ] Breaking change
- [ ] Documentation is updated
