### PR TITLE
Support PDFs in iOS caches directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Name | Android | iOS | Description
 ---- | ------- | --- | -----------
 resource | ✓ | ✓ | A resource to render. It's possible to render PDF from `file`, `url` (should be [encoded](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI)) or `base64`
 resourceType | ✓ | ✓ | Should correspond to resource and can be: `file`, `url` or `base64`
-fileFrom | ✗ | ✓ | *iOS ONLY:* In case if `resourceType` is set to `file`, there are different way to search for it on [iOS file system](https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html). Currently `documentsDirectory`, `libraryDirectory`, `tempDirectory` and `bundle` are supported.
+fileFrom | ✗ | ✓ | *iOS ONLY:* In case if `resourceType` is set to `file`, there are different way to search for it on [iOS file system](https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html). Currently `documentsDirectory`, `libraryDirectory`, `cachesDirectory`, `tempDirectory` and `bundle` are supported.
 onLoad | ✓ | ✓ | Callback that is triggered when loading is completed
 onError | ✓ | ✓ | Callback that is triggered when loading has failed. And error is provided as a function parameter
 style | ✓ | ✓ | A [style](https://facebook.github.io/react-native/docs/style)

--- a/ReactNativeViewPDF/RNPDFView.m
+++ b/ReactNativeViewPDF/RNPDFView.m
@@ -119,6 +119,8 @@
         url = [self fileFromDirectoryURL:NSDocumentDirectory];
     } else if ([currentFileFrom isEqualToString:@"libraryDirectory"]) {
         url = [self fileFromDirectoryURL:NSLibraryDirectory];
+    } else if ([currentFileFrom isEqualToString:@"cachesDirectory"]) {
+        url = [self fileFromDirectoryURL:NSCachesDirectory];
     } else if ([currentFileFrom isEqualToString:@"tempDirectory"]) {
         url = [self fileFromDirectoryPath:NSTemporaryDirectory()];
     } else { // default is search
@@ -178,7 +180,7 @@
 }
 
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationResponse:(WKNavigationResponse *)navigationResponse decisionHandler:(void (^)(WKNavigationResponsePolicy))decisionHandler {
-    
+
     if ([navigationResponse.response isKindOfClass:[NSHTTPURLResponse class]]) {
         NSHTTPURLResponse * response = (NSHTTPURLResponse *)navigationResponse.response;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -75,12 +75,14 @@ interface PDFViewProps {
    *   - "bundle"
    *   - "documentsDirectory"
    *   - "libraryDirectory"
+   *   - "cachesDirectory"
    *   - "tempDirectory"
    */
   fileFrom?:
     | "bundle"
     | "documentsDirectory"
     | "libraryDirectory"
+    | "cachesDirectory"
     | "tempDirectory";
 
   urlProps?: PDFViewUrlProps;

--- a/src/RNPDFView.js
+++ b/src/RNPDFView.js
@@ -47,6 +47,7 @@ const componentInterface = {
      *   - "bundle"
      *   - "documentsDirectory"
      *   - "libraryDirectory"
+     *   - "cachesDirectory"
      *   - "tempDirectory"
      */
     fileFrom: PropTypes.string,

--- a/src/index.js
+++ b/src/index.js
@@ -82,9 +82,10 @@ type PropsType = {|
    *   - "bundle"
    *   - "documentsDirectory"
    *   - "libraryDirectory"
+   *   - "cachesDirectory"
    *   - "tempDirectory"
    */
-  fileFrom?: 'bundle' | 'documentsDirectory' | 'libraryDirectory' | 'tempDirectory',
+  fileFrom?: 'bundle' | 'documentsDirectory' | 'libraryDirectory' | 'cachesDirectory' | 'tempDirectory',
 
   urlProps?: UrlPropsType,
 


### PR DESCRIPTION
### Description of changes

On iOS, one other directory exposed by iOS and file-system libraries like expo-file-system is the iOS caches directory, represented by NSCachesDirectory ([code in expo-file-system](https://github.com/expo/expo/blob/e0e6d484eaaa2ee9cf3557b916b6e9efd161beb8/packages/expo-file-system/ios/EXFileSystem/EXFileSystem.m#L87). It's currently not possible to display files stored there.

This change adds a new `fileFrom` option called `cachesDirectory` that lets us read from there.

### I did Exploratory testing:
- [X] android
- [X] ios

### Can it be published to NPM?
- [ ] Breaking change
- [X] Documentation is updated