### PR TITLE
Add "enableAnnotations" prop to TS typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -109,6 +109,12 @@ interface PDFViewProps {
    * Used to locate in end-to-end tests
    */
   testID?: string;
+  
+  /**
+   * [Android only] A Boolean value. Enables rendering PDF annotations (such as comments, colors, or forms).
+   *   - false, default
+   */
+  enableAnnotations: boolean;
 }
 
 export default class PDFView extends Component<PDFViewProps, {}> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -114,7 +114,7 @@ interface PDFViewProps {
    * [Android only] A Boolean value. Enables rendering PDF annotations (such as comments, colors, or forms).
    *   - false, default
    */
-  enableAnnotations: boolean;
+  enableAnnotations?: boolean;
 }
 
 export default class PDFView extends Component<PDFViewProps, {}> {


### PR DESCRIPTION
### Description of changes
This adds the "enableAnnotations" prop to TS typing so that TypeScript does not complain and throw a type error when using it.

### I did Exploratory testing:
- [x] android
- [x] ios

### Can it be published to NPM?
- [ ] Breaking change
- [ ] Documentation is updated
