### PR TITLE
android: add packagingOptions to build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,6 +26,14 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    packagingOptions {
+        pickFirst 'lib/x86/libc++_shared.so'
+        pickFirst 'lib/x86_64/libjsc.so'
+        pickFirst 'lib/arm64-v8a/libjsc.so'
+        pickFirst 'lib/arm64-v8a/libc++_shared.so'
+        pickFirst 'lib/x86_64/libc++_shared.so'
+        pickFirst 'lib/armeabi-v7a/libc++_shared.so'
+    }
 }
 
 dependencies {


### PR DESCRIPTION
### Description of changes

Adding packagingOptions to build.gradle for issue #228  `2 files found with path 'lib/arm64-v8a/libc++_shared.so' from inputs:`

```
   packagingOptions {
        pickFirst 'lib/x86/libc++_shared.so'
        pickFirst 'lib/x86_64/libjsc.so'
        pickFirst 'lib/arm64-v8a/libjsc.so'
        pickFirst 'lib/arm64-v8a/libc++_shared.so'
        pickFirst 'lib/x86_64/libc++_shared.so'
        pickFirst 'lib/armeabi-v7a/libc++_shared.so'
    }
```

### I did Exploratory testing:
- [ ] android
- [ ] ios

### Can it be published to NPM?
- [ ] Breaking change
- [ ] Documentation is updated
